### PR TITLE
Added the `usecases` and their respective `repositories`

### DIFF
--- a/lib/data/failure.dart
+++ b/lib/data/failure.dart
@@ -1,0 +1,9 @@
+import 'package:equatable/equatable.dart';
+
+class Failure extends Equatable {
+  final String message;
+  const Failure({required this.message});
+  @override
+  // TODO: implement props
+  List<Object?> get props => [message];
+}

--- a/lib/data/repositories/firebase_auth_repository_impl.dart
+++ b/lib/data/repositories/firebase_auth_repository_impl.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+import 'package:nowingoogle/data/failure.dart';
+
+import '../../domain/repositories/firebase_auth_repository.dart';
+
+class FirebaseAuthRepositoryImpl implements FirebaseAuthRepository {
+  final FirebaseAuth auth;
+  const FirebaseAuthRepositoryImpl({required this.auth});
+
+  /// A helper method to link the `OAuthCredential` with a `FirebaseAuth` account
+  ///
+  /// - If there's a **network failure** or **exception** thrown from Firebase, then [Failure] is returned
+  ///
+  /// - If the signIn was **successful**, a [bool] is return which states whether its the user is on the platform for the **first time**.
+  @override
+  Future<Either<Failure, bool>> linkWithFirebase(
+      OAuthCredential credential) async {
+    try {
+      final userCredential = await auth.signInWithCredential(credential);
+      return Right(userCredential.additionalUserInfo?.isNewUser ?? true);
+    } on SocketException {
+      return const Left(
+          Failure(message: "Oops! You're not connected to the interet"));
+    } on FirebaseAuthException catch (e) {
+      switch (e.code) {
+        case "account-exists-with-different-credential":
+          return const Left(Failure(message: ""));
+        case "invalid-credential":
+          return const Left(
+              Failure(message: "Expired or malformed credentials."));
+        case "user-disabled":
+          return const Left(Failure(message: ""));
+        case "user-not-found":
+          return const Left(Failure(message: ""));
+        default:
+          return const Left(Failure(message: ""));
+      }
+    }
+  }
+}

--- a/lib/data/repositories/google_auth_repository_impl.dart
+++ b/lib/data/repositories/google_auth_repository_impl.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'package:google_sign_in/google_sign_in.dart';
+
+import 'package:nowingoogle/data/failure.dart';
+
+import '../../domain/repositories/google_auth_repository.dart';
+
+class GoogleAuthRepositoryImpl implements GoogleAuthRepository {
+  final GoogleSignIn googleSignIn;
+  const GoogleAuthRepositoryImpl({required this.googleSignIn});
+
+  @override
+  Future<Either<Failure, OAuthCredential>> signIn() async {
+    try {
+      final request = await googleSignIn.signIn();
+      final auth = await request?.authentication;
+      if (auth == null) {
+        return const Left(
+            Failure(message: "Oops! Failed to retrive credentials."));
+      } else {
+        final OAuthCredential credential = GoogleAuthProvider.credential(
+            idToken: auth.idToken, accessToken: auth.accessToken);
+        return Right(credential);
+      }
+    } on SocketException {
+      return const Left(Failure(message: "Internet Not Connected"));
+    } on FirebaseAuthException {
+      return const Left(Failure(message: "Oops! Server error."));
+    } on FirebaseException {
+      return const Left(Failure(message: "Oops! Server error."));
+    } on Exception {
+      return const Left(Failure(message: "Oops! Please try after some time."));
+    }
+  }
+}

--- a/lib/domain/repositories/firebase_auth_repository.dart
+++ b/lib/domain/repositories/firebase_auth_repository.dart
@@ -1,0 +1,9 @@
+import 'package:dartz/dartz.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+import '../../data/failure.dart';
+
+abstract class FirebaseAuthRepository {
+  Future<Either<Failure, bool>> linkWithFirebase(OAuthCredential credential);
+}

--- a/lib/domain/repositories/google_auth_repository.dart
+++ b/lib/domain/repositories/google_auth_repository.dart
@@ -1,0 +1,9 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:nowingoogle/data/failure.dart';
+
+abstract class GoogleAuthRepository {
+  Future<Either<Failure, OAuthCredential>> signIn();
+}

--- a/lib/domain/usecases/firebase_auth_usecase.dart
+++ b/lib/domain/usecases/firebase_auth_usecase.dart
@@ -1,4 +1,20 @@
-class FirebaseAuthUseCase{
+import 'package:dartz/dartz.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:nowingoogle/domain/repositories/firebase_auth_repository.dart';
+import 'package:nowingoogle/domain/usecases/google_auth_usecase.dart';
+import 'package:nowingoogle/domain/usecases/oath_usecase.dart';
 
-  const FirebaseAuthUseCase({});
+import '../../data/failure.dart';
+
+class FirebaseAuthUseCase {
+  final FirebaseAuthRepository firebaseAuthRepository;
+  final OAuthUseCase oAuthUseCase;
+  const FirebaseAuthUseCase(
+      {required this.firebaseAuthRepository, required this.oAuthUseCase});
+
+  Future<Either<Failure, bool>> signInUser() async {
+    final credential = await oAuthUseCase.signInUser();
+    return credential.fold((l) => Left(l),
+        (r) async => await firebaseAuthRepository.linkWithFirebase(r));
+  }
 }

--- a/lib/domain/usecases/google_auth_usecase.dart
+++ b/lib/domain/usecases/google_auth_usecase.dart
@@ -1,0 +1,17 @@
+import 'package:dartz/dartz.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:nowingoogle/domain/usecases/oath_usecase.dart';
+
+import '../../data/failure.dart';
+import '../repositories/google_auth_repository.dart';
+
+class GoogleAuthUseCase implements OAuthUseCase {
+  final GoogleAuthRepository googleAuthRepository;
+  const GoogleAuthUseCase({required this.googleAuthRepository});
+
+  @override
+  Future<Either<Failure, OAuthCredential>> signInUser() {
+    return googleAuthRepository.signIn();
+  }
+}

--- a/lib/domain/usecases/oath_usecase.dart
+++ b/lib/domain/usecases/oath_usecase.dart
@@ -1,0 +1,8 @@
+import 'package:dartz/dartz.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../../data/failure.dart';
+
+abstract class OAuthUseCase {
+  Future<Either<Failure, OAuthCredential>> signInUser();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:nowingoogle/color_schemes.g.dart';
 
 void main() {
   runApp(const MyApp());
@@ -14,12 +15,17 @@ class MyApp extends StatelessWidget {
         colorScheme: lightColorScheme,
         useMaterial3: true,
       ),
+      darkTheme: ThemeData(
+        colorScheme: darkColorScheme,
+        useMaterial3: true,
+      ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
+  final String title;
   const MyHomePage({super.key, required this.title});
 
   @override
@@ -27,7 +33,6 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
- 
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -169,6 +169,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  dartz:
+    dependency: "direct main"
+    description:
+      name: dartz
+      sha256: e6acf34ad2e31b1eb00948692468c30ab48ac8250e0f0df661e29f12dd252168
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   extension_google_sign_in_as_googleapis_auth:
     dependency: "direct main"
     description:
@@ -405,18 +421,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -514,10 +530,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -554,10 +570,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.5.1"
   typed_data:
     dependency: transitive
     description:
@@ -670,14 +686,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   xml:
     dependency: transitive
     description:
@@ -695,5 +703,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.6 <4.0.0"
   flutter: ">=3.7.0-0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.1.0-155.0.dev <4.0.0"
+  sdk: ">=3.0.6 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -46,6 +46,8 @@ dependencies:
   extension_google_sign_in_as_googleapis_auth: ^2.0.9
   cloud_firestore: ^4.8.0
   url_launcher: ^6.1.11
+  dartz: ^0.10.1
+  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Signed-off-by: Manas Malla <manasmalla.dev@gmail.com>

1. Added the `OAuthUseCase`, an abstract class responsible for structuring the different providers supported by `Firebase` and retriving the `OAuthCredential`
2. Added the `GoogleAuthUseCase` which implements the `OAuthUseCase` and returns the respective `OAuthCredential` from Google Sign In Provider
3. Added the `FirebaseAuthUseCase` which links a `OAuthCredential` with a `FirebaseAuth` Account and returns whether the user is starter.
4. Added the respective repositories for GoogleSignIn and FirebaseAuth which handle the authentication and migration of data types and handle the excpetions.
5. Added the `Failure` equatable data classes to handle errors